### PR TITLE
Update d.txt

### DIFF
--- a/src/chrome/locale/d.txt
+++ b/src/chrome/locale/d.txt
@@ -10,7 +10,7 @@ gl-ES
 hu-HU
 hy-AM
 it-IT
-ja-JP
+ja
 ko-KR
 nb-NO
 nl


### PR DESCRIPTION
Incorrect locale name in Japanese.
It is "ja", not "ja-JP".

The locale name "ja-JP" does not exist in Mozilla products.

"ja" = for Windows,Linux
"ja-JP-mac" = for macOS

If you don't specify an OS, just use "ja".
So please correct all Japanese locale names to "ja".