### PR TITLE
Update addon-developer-support and use Services global variable if possible

### DIFF
--- a/.scratch/printU.js
+++ b/.scratch/printU.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );

--- a/.scratch/putils2.js
+++ b/.scratch/putils2.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, you can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 var { XPCOMUtils } = ChromeUtils.import(
   "resource://gre/modules/XPCOMUtils.jsm"
 );

--- a/src/api/NotifyTools/implementation.js
+++ b/src/api/NotifyTools/implementation.js
@@ -2,6 +2,12 @@
  * This file is provided by the addon-developer-support repository at
  * https://github.com/thundernest/addon-developer-support
  *
+ * Version 1.5
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.4
+ *  - updated implementation to not assign this anymore
+ * 
  * Version 1.3
  *  - moved registering the observer into startup
  *
@@ -17,58 +23,54 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-// Get various parts of the WebExtension framework that we need.
-var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { ExtensionSupport } = ChromeUtils.import("resource:///modules/ExtensionSupport.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+"use strict";
 
-var NotifyTools = class extends ExtensionCommon.ExtensionAPI {
-  getAPI(context) {
-    var self = this;
+(function (exports) {
 
-    return {
-      NotifyTools: {
+  // Get various parts of the WebExtension framework that we need.
+  var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
+  var Services = globalThis.Services || 
+    ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
-        notifyExperiment(data) {
-          return new Promise(resolve => {
-            Services.obs.notifyObservers(
-              { data, resolve },
-              "NotifyExperimentObserver",
-              self.extension.id
-            );
-          });
-        },
+  var observerTracker = new Set();
 
-        onNotifyBackground: new ExtensionCommon.EventManager({
-          context,
-          name: "NotifyTools.onNotifyBackground",
-          register: (fire) => {
-            let trackerId = self.observerTrackerNext++;
-            self.observerTracker[trackerId] = fire.sync;
-            return () => {
-              delete self.observerTracker[trackerId];
-            };
+  class NotifyTools extends ExtensionCommon.ExtensionAPI {
+    getAPI(context) {
+      return {
+        NotifyTools: {
+
+          notifyExperiment(data) {
+            return new Promise(resolve => {
+              Services.obs.notifyObservers(
+                { data, resolve },
+                "NotifyExperimentObserver",
+                context.extension.id
+              );
+            });
           },
-        }).api(),
 
-      }
-    };
-  }
+          onNotifyBackground: new ExtensionCommon.EventManager({
+            context,
+            name: "NotifyTools.onNotifyBackground",
+            register: (fire) => {
+              observerTracker.add(fire.sync);
+              return () => {
+                observerTracker.delete(fire.sync);
+              };
+            },
+          }).api(),
 
-  // Force API to run at startup, otherwise event listeners might not be added at the requested time. Also needs
-  // "events": ["startup"] in the experiment manifest
+        }
+      };
+    }
 
-  onStartup() {
-    let self = this;
-
-    this.observerTracker = {};
-    this.observerTrackerNext = 1;
-
-    this.onNotifyBackgroundObserver = {
-      observe: async function (aSubject, aTopic, aData) {
+    // Force API to run at startup, otherwise event listeners might not be added at the requested time. Also needs
+    // "events": ["startup"] in the experiment manifest
+    onStartup() {
+      this.onNotifyBackgroundObserver = async (aSubject, aTopic, aData) => {
         if (
-          Object.keys(self.observerTracker).length > 0 &&
-          aData == self.extension.id
+          observerTracker.size > 0 &&
+          aData == this.extension.id
         ) {
           let payload = aSubject.wrappedJSObject;
 
@@ -77,7 +79,7 @@ var NotifyTools = class extends ExtensionCommon.ExtensionAPI {
           if (payload.resolve) {
             let observerTrackerPromises = [];
             // Push listener into promise array, so they can run in parallel
-            for (let listener of Object.values(self.observerTracker)) {
+            for (let listener of observerTracker.values()) {
               observerTrackerPromises.push(listener(payload.data));
             }
             // We still have to await all of them but wait time is just the time needed
@@ -101,33 +103,37 @@ var NotifyTools = class extends ExtensionCommon.ExtensionAPI {
           } else {
             // Older version of NotifyTools, which is not sending a resolve function, deprecated.
             console.log("Please update the notifyTools API and the notifyTools script to at least v1.5");
-            for (let listener of Object.values(self.observerTracker)) {
+            for (let listener of observerTracker.values()) {
               listener(payload.data);
             }
           }
         }
-      },
-    };
-    // Add observer for notifyTools.js
-    Services.obs.addObserver(
-      this.onNotifyBackgroundObserver,
-      "NotifyBackgroundObserver",
-      false
-    );
-  }
+      };
 
-  onShutdown(isAppShutdown) {
-    if (isAppShutdown) {
-      return; // the application gets unloaded anyway
+      // Add observer for notifyTools.js
+      Services.obs.addObserver(
+        this.onNotifyBackgroundObserver,
+        "NotifyBackgroundObserver",
+        false
+      );
     }
 
-    // Remove observer for notifyTools.js
-    Services.obs.removeObserver(
-      this.onNotifyBackgroundObserver,
-      "NotifyBackgroundObserver"
-    );
+    onShutdown(isAppShutdown) {
+      if (isAppShutdown) {
+        return; // the application gets unloaded anyway
+      }
 
-    // Flush all caches
-    Services.obs.notifyObservers(null, "startupcache-invalidate");
-  }
-};
+      // Remove observer for notifyTools.js
+      Services.obs.removeObserver(
+        this.onNotifyBackgroundObserver,
+        "NotifyBackgroundObserver"
+      );
+
+      // Flush all caches
+      Services.obs.notifyObservers(null, "startupcache-invalidate");
+    }
+  };
+
+  exports.NotifyTools = NotifyTools;
+
+})(this)

--- a/src/api/WindowListener/implementation.js
+++ b/src/api/WindowListener/implementation.js
@@ -19,7 +19,9 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionSupport } = ChromeUtils.import(
   "resource:///modules/ExtensionSupport.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var WindowListener = class extends ExtensionCommon.ExtensionAPI {
   log(msg) {
@@ -406,7 +408,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
+          prefsObj.Services = globalThis.Services || ChromeUtils.import(
             "resource://gre/modules/Services.jsm"
           ).Services;
           prefsObj.pref = function (aName, aDefault) {

--- a/src/api/WindowListener/implementation2.js
+++ b/src/api/WindowListener/implementation2.js
@@ -18,7 +18,9 @@ var { ExtensionCommon } = ChromeUtils.import(
 var { ExtensionSupport } = ChromeUtils.import(
   "resource:///modules/ExtensionSupport.jsm"
 );
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || ChromeUtils.import(
+  "resource://gre/modules/Services.jsm"
+).Services;
 
 var WindowListener = class extends ExtensionCommon.ExtensionAPI {
   log(msg) {
@@ -405,7 +407,7 @@ var WindowListener = class extends ExtensionCommon.ExtensionAPI {
           let url = context.extension.rootURI.resolve(defaultUrl);
 
           let prefsObj = {};
-          prefsObj.Services = ChromeUtils.import(
+          prefsObj.Services = globalThis.Services || ChromeUtils.import(
             "resource://gre/modules/Services.jsm"
           ).Services;
           prefsObj.pref = function (aName, aDefault) {

--- a/src/api/notificationbar/implementation.js
+++ b/src/api/notificationbar/implementation.js
@@ -4,7 +4,9 @@
 
 var { EventEmitter, EventManager, ExtensionAPI } = ExtensionCommon;
 var { ExtensionError } = ExtensionUtils;
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 class Notification {
   constructor(notificationId, properties, parent) {

--- a/src/chrome/content/messageWindowOL.js
+++ b/src/chrome/content/messageWindowOL.js
@@ -1,4 +1,6 @@
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 // Import any needed modules.
 var ADDON_ID = "PrintingToolsNG@cleidigh.kokkini.net";

--- a/src/chrome/content/messengerOL.js
+++ b/src/chrome/content/messengerOL.js
@@ -3,7 +3,9 @@
 // Load all scripts from original overlay file - creates common scope
 // onLoad() installs each overlay xul fragment
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 // Import any needed modules.
 var ADDON_ID = "PrintingToolsNG@cleidigh.kokkini.net";

--- a/src/chrome/content/modules/list.controller.js
+++ b/src/chrome/content/modules/list.controller.js
@@ -1,4 +1,6 @@
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 class ListController {
 

--- a/src/chrome/content/notifyTools.js
+++ b/src/chrome/content/notifyTools.js
@@ -8,14 +8,17 @@ var ADDON_ID = "PrintingToolsNG@cleidigh.kokkini.net";
  * For usage descriptions, please check:
  * https://github.com/thundernest/addon-developer-support/tree/master/scripts/notifyTools
  *
- * Version: 1.5
+ * Version 1.6
+ * - adjusted to Thunderbird Supernova (Services is now in globalThis)
+ *
+ * Version 1.5
  * - deprecate enable(), disable() and registerListener()
  * - add setAddOnId()
  *
- * Version: 1.4
+ * Version 1.4
  * - auto enable/disable
  *
- * Version: 1.3
+ * Version 1.3
  * - registered listeners for notifyExperiment can return a value
  * - remove WindowListener from name of observer
  *
@@ -26,7 +29,8 @@ var ADDON_ID = "PrintingToolsNG@cleidigh.kokkini.net";
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var Services = globalThis.Services || 
+  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
 
 var notifyTools = {
   registeredCallbacks: {},

--- a/src/chrome/content/printerSettings.js
+++ b/src/chrome/content/printerSettings.js
@@ -32,7 +32,9 @@ st,
 
 */
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 
 var window3Pane = Cc["@mozilla.org/appshell/window-mediator;1"]
   .getService(Ci.nsIWindowMediator)

--- a/src/chrome/content/ptng-options.js
+++ b/src/chrome/content/ptng-options.js
@@ -5,7 +5,9 @@ printerSettings,
 utils,
 */
 
-var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+var Services = globalThis.Services || ChromeUtils.import(
+  'resource://gre/modules/Services.jsm'
+).Services;
 var { strftime } = ChromeUtils.import("chrome://printingtoolsng/content/strftime.js");
 Services.scriptloader.loadSubScript("chrome://printingtoolsng/content/utils.js");
 

--- a/src/chrome/content/utils.js
+++ b/src/chrome/content/utils.js
@@ -11,7 +11,9 @@ latinizeString,
 */
 
 if (!Services) {
-  var { Services } = ChromeUtils.import('resource://gre/modules/Services.jsm');
+  var Services = globalThis.Services || ChromeUtils.import(
+    'resource://gre/modules/Services.jsm'
+  ).Services;
 }
 
 Services.scriptloader.loadSubScript("chrome://printingtoolsng/content/modules/latinize.js");


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 .
Services global variable is available in WebExtensions experiments API global
from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 ,
and also available in all system globals from version 104
https://bugzilla.mozilla.org/show_bug.cgi?id=1667455 ,
and those code doesn't have to import Services.jsm for recent versions.